### PR TITLE
Set username as identity

### DIFF
--- a/src/ogc_service.py
+++ b/src/ogc_service.py
@@ -9,6 +9,7 @@ import requests
 
 from qwc_services_core.permissions_reader import PermissionsReader
 from qwc_services_core.runtime_config import RuntimeConfig
+from qwc_services_core.auth import get_username
 from wfs_response_filters import wfs_describefeaturetype, \
     wfs_getcapabilities, wfs_getfeature
 from wms_response_filters import wms_getcapabilities, wms_getfeatureinfo
@@ -114,7 +115,7 @@ class OGCService:
                 del params[parameter_name]
 
             if identity:
-                params[parameter_name] = identity
+                params[parameter_name] = get_username(identity)
 
         # get permission
         permission = self.service_permissions(

--- a/src/server.py
+++ b/src/server.py
@@ -4,7 +4,7 @@ import requests
 import os
 
 
-from qwc_services_core.auth import auth_manager, optional_auth, get_identity, get_username  # noqa: E402
+from qwc_services_core.auth import auth_manager, optional_auth, get_identity  # noqa: E402
 from qwc_services_core.tenant_handler import TenantHandler, TenantPrefixMiddleware, TenantSessionInterface
 from qwc_services_core.runtime_config import RuntimeConfig
 from ogc_service import OGCService
@@ -50,7 +50,7 @@ def ogc_service_handler():
 
 
 def get_identity_or_auth(ogc_service):
-    identity = get_username(get_identity())
+    identity = get_identity()
     if not identity and ogc_service.basic_auth_login_url:
         # Check for basic auth
         auth = request.authorization

--- a/src/server.py
+++ b/src/server.py
@@ -4,7 +4,7 @@ import requests
 import os
 
 
-from qwc_services_core.auth import auth_manager, optional_auth, get_identity  # noqa: E402
+from qwc_services_core.auth import auth_manager, optional_auth, get_identity, get_username  # noqa: E402
 from qwc_services_core.tenant_handler import TenantHandler, TenantPrefixMiddleware, TenantSessionInterface
 from qwc_services_core.runtime_config import RuntimeConfig
 from ogc_service import OGCService
@@ -50,7 +50,7 @@ def ogc_service_handler():
 
 
 def get_identity_or_auth(ogc_service):
-    identity = get_identity()
+    identity = get_username(get_identity())
     if not identity and ogc_service.basic_auth_login_url:
         # Check for basic auth
         auth = request.authorization


### PR DESCRIPTION
Hi! Since I'm using the "qgis_server_identity_parameter" and now that 'get_identity()' returns a dictionary with the _username_ and _user_id_, the URL passed to qgis server looks like this: **&USER=username&USER=user_id**

I solved this using _get_username_ to set the username as _identity_ directly